### PR TITLE
Fixe %eet_2% reference and Ellesime snark

### DIFF
--- a/themed_tweaks/dialogues/bg2_snark.d
+++ b/themed_tweaks/dialogues/bg2_snark.d
@@ -4,6 +4,14 @@
 /////////////////////////////////////////////////////////////
 
 EXTEND_BOTTOM SUELLE2 18
-	IF ~ReputationLT(Player1,10) !Global("#L_Snark","GLOBAL",0)~ THEN REPLY @3000 /* ~Only partially?~ */ + 19
-	IF ~ReputationGT(Player1,9) !Global("#L_Snark","GLOBAL",0)~ THEN REPLY @3000 /* ~Only partially?~ */ + 20
+	IF ~ReputationLT(Player1,10) !Global("#L_Snark","GLOBAL",0)~ THEN REPLY @3000 /* ~Only partially?~ */ DO ~SetGlobal("soa_complete","GLOBAL",1)
+ClearAllActions()
+StartCutSceneMode()
+StartCutSceneEx("cut100a",FALSE)
+~ EXIT
+	IF ~ReputationGT(Player1,9) !Global("#L_Snark","GLOBAL",0)~ THEN REPLY @3000 /* ~Only partially?~ */ DO ~SetGlobal("soa_complete","GLOBAL",1)
+ClearAllActions()
+StartCutSceneMode()
+StartCutSceneEx("cut100b",FALSE)
+~ EXIT
 END

--- a/themed_tweaks/dialogues/sod_stat_weak_poison.d
+++ b/themed_tweaks/dialogues/sod_stat_weak_poison.d
@@ -210,7 +210,7 @@ ALTER_TRANS BDRASAAD
 	  "TRIGGER" ~Global("#L_SoDStat_WeakPoison","GLOBAL",0)~
 	END
 EXTEND_BOTTOM BDRASAAD 38
-	IF ~Global("#L_SoDStat_WeakPoison","GLOBAL",1)~ THEN REPLY #234637 /* ~The Shining Lady Caelar happened. Or assassins who bore her mark did, at any rate.~ */ GOTO RASAAD_ATTACK
+	IF ~Global("#L_SoDStat_WeakPoison","GLOBAL",1)~ THEN REPLY #%eet_2%34637 /* ~The Shining Lady Caelar happened. Or assassins who bore her mark did, at any rate.~ */ GOTO RASAAD_ATTACK
 	IF ~Global("#L_SoDStat_WeakPoison","GLOBAL",1)~ THEN REPLY @128 /* ~Assassins in service to Caelar Argent penetrated the Ducal Palace and attempted to poison me.~ */ GOTO 25
 END
 

--- a/themed_tweaks/readme.themed_tweaks.french.txt
+++ b/themed_tweaks/readme.themed_tweaks.french.txt
@@ -18,37 +18,44 @@ DESCRIPTION
 ------------------------------------------------------------------------
 SoD - Donner a Imoen une baguette spéciale lors de l'attaque du palais - par Lauriel
 ------------------------------------------------------------------------
+
 Imoen disposera d'une baguette de projectiles magiques qui tirera jusqu'à trois projectiles à la fois pour lui permettre d'être mono-classée tout en lui permettant de participer au combat comme prévu.  Pour limiter son efficacité, la baguette ne sera utilisable que par Imoen.
 
 ------------------------------------------------------------------------
 SoD - Permettre au PC de porter secours a Imoen après l'attaque du palais - par Lauriel
 ------------------------------------------------------------------------
+
 Permet au PC d'apporter son aide à Imoen après que les agents de Caelar ait été vaincue.
 
 ------------------------------------------------------------------------
 SoD - Observations basées sur les statistiques et options de quête - par Lauriel
 ------------------------------------------------------------------------
-Ajoute des commentaires sur le déroulement de la situation et des options de quête en fonction de diverses statistiques.
+
+Ajoute de commentaires sur le déroulement de la situation et des options de quête en fonction de diverses statistiques. (Ce composant es similaire à celui du mod Road to Discovery)
 
 ------------------------------------------------------------------------
 SoD - Éviter le tour de la ville avec Corwin Schael - par Lauriel
 ------------------------------------------------------------------------
+
 Permet au PC de se promener à la Porte de Baldur avec ou sans Corwin.
 
 ------------------------------------------------------------------------
 SoD - Quête : Péripéties au Pont de la Voie Côtière - par Lauriel
 ------------------------------------------------------------------------
-Ajoute une nouvelle quête d'exploration en rapport au Pont de la Voie Côtière.
+
+Ajoute une nouvelle quête d'exploration dans la zone du Pont de la Voie Côtière.
 
 ------------------------------------------------------------------------
 SoD/BG2EE - Ajoutez un peu de mordant aux dialogues - par Lauriel
 ------------------------------------------------------------------------
+
 Ajoute juste quelques commentaires amusants et sarcastiques à des dialogues autrement étouffants ou insipides.
 ** PROGRES : Au palais dans SoD et des remarques désobligeantes au premier Camp sont terminés. Un seul petit commentaire dans BG2 pour l'instant.
 
 ------------------------------------------------------------------------
 SoD/BG2EE - Supprimer les scenes coupees auxquelles le PC ne devrait pas avoir accès - par Lauriel
 ------------------------------------------------------------------------
+
 À moins qu'il n'y ait une raison pour le PC de voir une cinématique, comme dans bassin de scrutation, les cinématiques concernant les autres PNJ et non directement dans la ligne de vue du PC sont ignorées.
 Note : ceci supprime également les cinématiques ajoutées par d'autres mods, par exemple le composant de I4E (Imoen Forever) "Play cutscene with Imoen and Duke Jannath".
 ** PROGRESS : SoD jusqu'au 1er camp est terminé.  Le reste de SoD et BG2 reste à faire.
@@ -56,17 +63,20 @@ Note : ceci supprime également les cinématiques ajoutées par d'autres mods, p
 ------------------------------------------------------------------------
 SoD/BG2EE - Déplacer les rêves avec Irenicus de SoD a BG2EE - par Lauriel
 ------------------------------------------------------------------------
+
 Irenicus ne devrait pas avoir assez d'influence sur le PC pour pouvoir envahir ses rêves dans SoD.  Ces rêves sont déplacés vers BG2 où ils seront disponibles pour que d'autres mods puissent les utiliser.
 ** PROGRES : Les rêves de SoD sont supprimés.  Il faut encore trouver des endroits appropriés pour les placer dans BG2.
 
 ------------------------------------------------------------------------
 BG2EE - Donner a Imoen la capacité innée, projectiles magiques, pour la scene de la Promenade de Waukyne. - par Lauriel
 ------------------------------------------------------------------------
-Au cas où Imoen n'aurait pas été jumelée en mage, elle reçoit une capacité innée lui permettant de lancée projectiles magiques deux fois au début de BG2.  Une potion sera fournie dans la donjon d'Irenicus pour s'assurer qu'elle en est bien capable lorsque de votre arrivés à la promenade.
+
+Au cas où Imoen n'aurait pas été jumelée en mage, elle reçoit une capacité innée lui permettant de lancer projectiles magiques deux fois au début de BG2.  Une potion sera fournie dans la donjon d'Irenicus pour s'assurer qu'elle en est bien capable lorsque de votre arrivés à la promenade.
 
 ------------------------------------------------------------------------
 BG2EE - Utiliser la cinématique d'Irenicus en enfer comme un rêve qui restaure vos pouvoirs d'enfant de Bhaal. - par Lauriel
 ------------------------------------------------------------------------
+
 Ce composant est également dans le mod Transitions.  Il sera ignoré s'il est déjà installé.
 
 ------------------------------------------------------------------------

--- a/themed_tweaks/readme.themed_tweaks_v2.french.txt
+++ b/themed_tweaks/readme.themed_tweaks_v2.french.txt
@@ -20,39 +20,46 @@ DESCRIPTION
 ------------------------------------------------------------------------
 BG1EE/BG2EE - Donner des raisons valables aux joueurs d'alignement bon de rentrer dans les maisons.
 ------------------------------------------------------------------------
+
 This isn't for every house in the game.  A good aligned PC has no business ransacking every house in the realm.  But with this component, the PC will at least be prompted to enter the important ones. Inn and shop keepers will be a font of information concerning where to hand in certain quest items, for example.  If BG1RE is installed, this component will also allow for the Camryn/Tamah book collection quest to be completed without having to steal or break into homes.
 PROGRESS: BG1 finished, BG2 yet to do
 
 ------------------------------------------------------------------------
 BG1EE/SoD/BG2EE - Corriger les scenes coupées qui réorganisent le groupe
 ------------------------------------------------------------------------
+
 Some cut scenes take on too much license with the arrangement of the group, especially before a fight.  This component will try to alleviate that.
 PROGRESS: BG1 finished, SoD and BG2 yet to do
 
 ------------------------------------------------------------------------
 BGEE/SoD/BG2EE - Make sure unique items stay unique
 ------------------------------------------------------------------------
+
 Items that are made unique by a specific history are kept unique.  For example, if you return the Heart of the Golem to the revenant, you'll not find another anywhere in the game. There will, however, be multiple +2 daggers with a more generic background to be found throughout the realms that are almost as good. 
 PROGRESS: BG1 in development, SoD and BG2 yet to do
 
 ------------------------------------------------------------------------
-BG1EE - Permettre a la quete de Rasaad d'etre completee avant le chapitre 5
+BG1EE - Permettre a la quete de Rasaad d'etre completée avant le chapitre 5
 ------------------------------------------------------------------------
+
 The encounter that is necessary to begin Rasaad's companion quest will happen at Beregost if the quest timer expires before chapter 5. If it expires in chapter 5, the quest will progress as usual.
 
 ------------------------------------------------------------------------
 BG1EE - Ajouter Caelar essaye de recruter le PC après les mines de Nashkel et la fin de ToSC.
 ------------------------------------------------------------------------
+
 PROGRESS: Post-Nashkel encounter finished, post ToSC yet to do
 
 ------------------------------------------------------------------------
 BG1EE - Permettre a Dorn de rejoindre un groupe de personnage bon afin d'accomplir sa quête de vengeance.
 ------------------------------------------------------------------------
+
 If a heroic group wants to help Dorn get his revenge, they may now do so.  At the start of Chapter 5, Dorn will rejoin your group no matter how shiny you are.
 
 ------------------------------------------------------------------------
 BG1EE/SoD - Suppression de references erratiques se rapportant a la condition d'enfant de Bhaal du PC.
 ------------------------------------------------------------------------
+
 PROGRESS: BG1 in development, SoD yet to do
 If BG1NPC is to be installed, please do so before this component
 


### PR DESCRIPTION
@Gitjas 

- [%eet_2%](https://github.com/lzenner/themed_tweaks/pull/12/commits/cf8705e35582a8858bccd4c27873cccdf5f938e8#diff-69a384cba828923b1e62a347746806548845bd4857656bea95263ecd0fc5b281) : same issue mentionned [here](https://www.gibberlings3.net/forums/topic/33480-road-to-discovery-bugthread/?do=findComment&comment=351135)

- Ellesime snark
At the end of SUELLE2.dlg),the last two blocks are useless because block 18 refers to cut100a.bcs and cut100b.bcs, which have the same lines as the two ignored blocks, cut100a.bcs and cut100b.bcs finalize SoA and launch the transition.
[bg2_snark.d](https://github.com/lzenner/themed_tweaks/blob/main/themed_tweaks/dialogues/bg2_snark.d) add a line that will link to the two “unused” blocks instead of sending to the cutscenes. And then players are stuck in the temple of Rilifiane.
The fixe simply duplicates the actions of the original block 18 of SUELLE2.dlg in order to launch the cutscenes and transition normally.